### PR TITLE
Filter show gym when using /start ****

### DIFF
--- a/logic.php
+++ b/logic.php
@@ -1094,6 +1094,7 @@ function raid_get_gyms_list_keys($searchterm)
                 FROM      gyms
                 WHERE     gym_name LIKE '$searchterm%'
                 OR        gym_name LIKE '%$searchterm%'
+		AND       show_gym LIKE 1
                 ORDER BY
                   CASE
                     WHEN  gym_name LIKE '$searchterm%' THEN 1


### PR DESCRIPTION
Searching for a gym with /start will now only look at gyms that have 1 in show_gym.