### PR TITLE
Raidpicture form Thundurus Landorus

### DIFF
--- a/raidpicture.php
+++ b/raidpicture.php
@@ -199,7 +199,9 @@ if($time_now < $raid['end_time']) {
         '493-dragon' => '26',
         '493-dark' => '27',
         '493-fairy' => '28',
-        '641-normal' => '11'
+        '641-normal' => '11',
+	'642-normal' => '11',
+	'645-normal' => '11'
     );
 
     // Map pokemon form for filename


### PR DESCRIPTION
Thundurus and Landorus don't have a normal form in Pokemon Go. It should take form 11.