### PR TITLE
If the user is not allowed to 'create' check 'list' permissions and run

### DIFF
--- a/commands/start.php
+++ b/commands/start.php
@@ -6,9 +6,16 @@ debug_log('START()');
 //debug_log($update);
 //debug_log($data);
 
-// Check access.
-$access = bot_access_check($update, 'create', false, true);
+// Check access, don't die if no access.
+$access = bot_access_check($update, 'create', true);
 
+if(!$access && bot_access_check($update, 'list', true)){
+  debug_log('No access to create, will do a list instead');
+  require('list.php');
+  exit;
+} else {
+  $access = bot_access_check($update, 'create', false, true);
+}
 // Raid event?
 if($config->RAID_POKEMON_DURATION_EVENT != $config->RAID_POKEMON_DURATION_SHORT) {
     // Always allow for Admins.


### PR DESCRIPTION
that instead on /start.

If raids are created with webhooks, the first time use of /start is
really confusing since it will tell you you can't create the raid
because it already exists. Now you can disable create and still have a
decent user experience.