### PR TITLE
Changed overview to only show one entry per raid

### DIFF
--- a/mods/overview_refresh.php
+++ b/mods/overview_refresh.php
@@ -32,7 +32,7 @@ $tg_json = [];
 foreach($overviews as $overview_row) {
     $request_raids = my_query("
             SELECT
-              raids.id,raids.pokemon,raids.pokemon_form,raids.start_time,raids.end_time,raids.gym_id,
+              raids.id, raids.pokemon, raids.pokemon_form, raids.start_time, raids.end_time, raids.gym_id,
               MAX(cleanup.message_id) as message_id,
               gyms.lat, gyms.lon, gyms.address, gyms.gym_name, gyms.ex_gym,
               TIME_FORMAT(TIMEDIFF(end_time, UTC_TIMESTAMP()) + INTERVAL 1 MINUTE, '%k:%i') AS t_left
@@ -43,7 +43,7 @@ foreach($overviews as $overview_row) {
             ON        raids.gym_id = gyms.id
             WHERE     cleanup.chat_id = '{$overview_row['chat_id']}'
             AND       raids.end_time>UTC_TIMESTAMP()
-            GROUP BY  cleanup.raid_id, raids.id, raids.pokemon, raids.pokemon_form, raids.start_time, raids.end_time, raids.gym_id, gyms.lat, gyms.lon, gyms.address, gyms.gym_name, gyms.ex_gym
+            GROUP BY  raids.id, raids.pokemon, raids.pokemon_form, raids.start_time, raids.end_time, raids.gym_id, gyms.lat, gyms.lon, gyms.address, gyms.gym_name, gyms.ex_gym
             ORDER BY  raids.end_time ASC, gyms.gym_name
     ");
     // Write active raids to array

--- a/mods/overview_refresh.php
+++ b/mods/overview_refresh.php
@@ -43,6 +43,7 @@ foreach($overviews as $overview_row) {
             ON        raids.gym_id = gyms.id
 	        WHERE     cleanup.chat_id = '{$overview_row['chat_id']}'
             AND       raids.end_time>UTC_TIMESTAMP()
+            GROUP BY  cleanup.raid_id
             ORDER BY  raids.end_time ASC, gyms.gym_name
     ");
     // Write active raids to array

--- a/mods/overview_refresh.php
+++ b/mods/overview_refresh.php
@@ -32,8 +32,8 @@ $tg_json = [];
 foreach($overviews as $overview_row) {
     $request_raids = my_query("
             SELECT
-              raids.*,
-              cleanup.message_id,
+              raids.id,raids.pokemon,raids.pokemon_form,raids.start_time,raids.end_time,raids.gym_id,
+              MAX(cleanup.message_id) as message_id,
               gyms.lat, gyms.lon, gyms.address, gyms.gym_name, gyms.ex_gym,
               TIME_FORMAT(TIMEDIFF(end_time, UTC_TIMESTAMP()) + INTERVAL 1 MINUTE, '%k:%i') AS t_left
             FROM      cleanup
@@ -41,9 +41,9 @@ foreach($overviews as $overview_row) {
             ON        raids.id = cleanup.raid_id
             LEFT JOIN gyms
             ON        raids.gym_id = gyms.id
-	        WHERE     cleanup.chat_id = '{$overview_row['chat_id']}'
+            WHERE     cleanup.chat_id = '{$overview_row['chat_id']}'
             AND       raids.end_time>UTC_TIMESTAMP()
-            GROUP BY  cleanup.raid_id
+            GROUP BY  cleanup.raid_id, raids.id, raids.pokemon, raids.pokemon_form, raids.start_time, raids.end_time, raids.gym_id, gyms.lat, gyms.lon, gyms.address, gyms.gym_name, gyms.ex_gym
             ORDER BY  raids.end_time ASC, gyms.gym_name
     ");
     // Write active raids to array


### PR DESCRIPTION
When using RAID_LOCATION mode, two messages are posted and two entries will be created to cleanup table. Changed overview to only show list of unique raid id's and link to the latest message posted per raid_id.
Tested in environment where sql_mode ONLY_FULL_GROUP_BY is enabled, should work.