### PR TITLE
Disable image build message notifications

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -60,3 +60,5 @@ jobs:
           token: ${{ secrets.TELEGRAM_TOKEN }}
           message: "New Docker image has been built: ${{ steps.meta.outputs.tags }}"
           disable_web_page_preview: true
+          disable_notification: true
+


### PR DESCRIPTION
The messages are still sent, just without triggering a notification.